### PR TITLE
fix for crash when you don't escape % using %% in LUA52

### DIFF
--- a/data_gen/gen_p_e_m/gen_p_e_m_from_yago.lua
+++ b/data_gen/gen_p_e_m/gen_p_e_m_from_yago.lua
@@ -46,9 +46,9 @@ while (line) do
     local x = ent_name:find('\\u')
     local code = ent_name:sub(x, x + 5)
     assert(unicode2ascii[code], code)
-    replace= unicode2ascii[code]
-    if(replace=="%") then
-	    replace="%%"
+    replace = unicode2ascii[code]
+    if(replace == "%") then
+	    replace = "%%"
     end
     ent_name = string.gsub(ent_name, code, replace)
   end

--- a/data_gen/gen_p_e_m/gen_p_e_m_from_yago.lua
+++ b/data_gen/gen_p_e_m/gen_p_e_m_from_yago.lua
@@ -50,7 +50,7 @@ while (line) do
     if(replace=="%") then
 	    replace="%%"
     end
-    ent_name = string.gsub(ent_name, code,replace)
+    ent_name = string.gsub(ent_name, code, replace)
   end
   
   ent_name = preprocess_ent_name(ent_name)

--- a/data_gen/gen_p_e_m/gen_p_e_m_from_yago.lua
+++ b/data_gen/gen_p_e_m/gen_p_e_m_from_yago.lua
@@ -46,7 +46,11 @@ while (line) do
     local x = ent_name:find('\\u')
     local code = ent_name:sub(x, x + 5)
     assert(unicode2ascii[code], code)
-    ent_name = string.gsub(ent_name, code, unicode2ascii[code])
+    replace= unicode2ascii[code]
+    if(replace=="%") then
+	    replace="%%"
+    end
+    ent_name = string.gsub(ent_name, code,replace)
   end
   
   ent_name = preprocess_ent_name(ent_name)


### PR DESCRIPTION
fix for crash when you don't escape `%` using `%%` in LUA52